### PR TITLE
Enable KLD resampling and parameterize prediction/measurement models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ install/
 log/
 demo_data/
 __pycache__/
+maps/
+bags/
+*.g2o

--- a/src/amcl_3d/CMakeLists.txt
+++ b/src/amcl_3d/CMakeLists.txt
@@ -66,6 +66,7 @@ install(TARGETS amcl_3d_node
 
 install(PROGRAMS
   tools/convert_ros1_bag_to_ros2.sh
+  scripts/publish_pcd.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/amcl_3d/README.md
+++ b/src/amcl_3d/README.md
@@ -90,6 +90,102 @@ ros2 launch amcl_3d amcl_3d_rosbag.launch.py \
   open_rviz:=false
 ```
 
+### PCD map publisher
+
+The rosbag launch can also load a PCD map file and publish it as a PointCloud2 topic
+with `transient_local` QoS (matching amcl_3d's map subscription):
+
+```bash
+ros2 launch amcl_3d amcl_3d_rosbag.launch.py \
+  bag_path:=/path/to/bag \
+  map_pcd_file:=/path/to/map.pcd \
+  map_pcd_frame:=map
+```
+
+### QoS overrides for bag playback
+
+Some bags require QoS overrides (e.g., `/tf_static` with `transient_local` durability).
+Pass a YAML file via `qos_overrides_path`:
+
+```bash
+ros2 launch amcl_3d amcl_3d_rosbag.launch.py \
+  bag_path:=/path/to/bag \
+  qos_overrides_path:=/path/to/qos_override.yaml
+```
+
+A default override file is included at `config/qos_override.yaml`.
+
+## Demo: Kinematic-ICP Husky Bag
+
+Full demo using a Kinematic-ICP Husky bag (2 min, Hesai lidar + wheel odom).
+
+### Step 1: Generate 3D map with lidarslam_ros2
+
+Terminal 1 — lidarslam:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source ~/workspace/ros/slam_ros2_ws/install/setup.bash
+
+PARAMS_FILE=$(ros2 pkg prefix lidarslam)/share/lidarslam/param/lidarslam.yaml
+
+ros2 run scanmatcher scanmatcher_node --ros-args \
+  -r /input_cloud:=/lidar_points \
+  --params-file "$PARAMS_FILE" \
+  -p use_sim_time:=true &
+
+ros2 run graph_based_slam graph_based_slam_node --ros-args \
+  --params-file "$PARAMS_FILE" \
+  -p use_sim_time:=true &
+```
+
+Terminal 2 — bag playback:
+
+```bash
+ros2 bag play bags/2024-08-23-11-05-41_0_clipped.mcap \
+  --clock 100 --rate 1.0 \
+  --qos-profile-overrides-path src/amcl_3d/config/qos_override.yaml
+```
+
+After bag finishes, save the map:
+
+```bash
+ros2 service call /map_save std_srvs/srv/Empty
+# Output: map.pcd in the current directory
+mkdir -p maps && mv map.pcd maps/kinematic_icp_husky.pcd
+```
+
+### Step 2: Run amcl_3d with the generated map
+
+One-liner using the rosbag launch:
+
+```bash
+ros2 launch amcl_3d amcl_3d_rosbag.launch.py \
+  bag_path:=bags/2024-08-23-11-05-41_0_clipped.mcap \
+  map_pcd_file:=$(pwd)/maps/kinematic_icp_husky.pcd \
+  input_odom:=/husky_velocity_controller/odom \
+  input_pc2:=/lidar_points \
+  qos_overrides_path:=$(ros2 pkg prefix amcl_3d)/share/amcl_3d/config/qos_override.yaml \
+  bag_rate:=0.5 \
+  bag_loop:=true
+```
+
+In a separate terminal, set the initial pose:
+
+```bash
+ros2 topic pub --once /initialpose geometry_msgs/msg/PoseWithCovarianceStamped \
+  '{header: {frame_id: "map"},
+    pose: {pose: {position: {x: 0, y: 0, z: 0}, orientation: {w: 1}},
+           covariance: [0.5,0,0,0,0,0, 0,0.5,0,0,0,0, 0,0,0.5,0,0,0,
+                        0,0,0,0.1,0,0, 0,0,0,0,0.1,0, 0,0,0,0,0,0.1]}}'
+```
+
+### Verification
+
+- `map → odom` TF: `ros2 run tf2_ros tf2_echo map odom`
+- Particles: `ros2 topic echo /particles --no-arr`
+- Current pose: `ros2 topic echo /current_pose`
+
 ## Notes
 
 - Ported to `ament_cmake` / `rclcpp` / ROS 2 launch.

--- a/src/amcl_3d/config/amcl_3d.params.yaml
+++ b/src/amcl_3d/config/amcl_3d.params.yaml
@@ -10,21 +10,34 @@ amcl_3d:
         alpha_slow: 0.05
         w_fast: 0.5
         w_slow: 0.5
-        noise_x_var: 1.0
-        noise_y_var: 1.0
-        noise_z_var: 0.2
-        noise_roll_var: 0.1
-        noise_pitch_var: 0.1
-        noise_yaw_var: 0.1
+        noise_x_var: 0.3
+        noise_y_var: 0.3
+        noise_z_var: 0.1
+        noise_roll_var: 0.05
+        noise_pitch_var: 0.05
+        noise_yaw_var: 0.05
       init_pose:
-        initial_particle_num: 100
+        initial_particle_num: 500
       resample_timing:
-        ess_ratio_threshold: 0.7
+        ess_ratio_threshold: 0.5
       kld_sampling:
         min_particle_num: 100
-        max_particle_num: 2000
+        max_particle_num: 5000
         delta: 0.5
         epsilon: 0.5
-        x_bin_width: 0.2
-        y_bin_width: 0.2
-        z_bin_width: 0.2
+        x_bin_width: 0.5
+        y_bin_width: 0.5
+        z_bin_width: 0.5
+      prediction_noise:
+        vel_scale_mean: 1.0
+        vel_scale_std: 0.2
+        vel_bias_mean: 0.0
+        vel_bias_std: 0.05
+        omega_scale_mean: 1.0
+        omega_scale_std: 0.2
+        omega_bias_mean: 0.0
+        omega_bias_std: 0.05
+      lidar_measurement:
+        random_sample_num: 300
+        max_dist: 1.0
+        sigma: 0.5

--- a/src/amcl_3d/config/qos_override.yaml
+++ b/src/amcl_3d/config/qos_override.yaml
@@ -1,0 +1,4 @@
+/tf_static:
+  reliability: reliable
+  durability: transient_local
+  history: keep_all

--- a/src/amcl_3d/include/amcl_3d/prediction_model/foo_prediction_model.hpp
+++ b/src/amcl_3d/include/amcl_3d/prediction_model/foo_prediction_model.hpp
@@ -9,6 +9,7 @@ class FooPredictionModel : public PredictionModelInterface
 {
 public:
   FooPredictionModel();
+  FooPredictionModel(const PredictionNoiseParam &noise_param);
   FooPredictionModel(const Eigen::Vector3d &vel, const Eigen::Vector3d &omega);
   bool predict(State &state, const double dt_sec) override;
   bool measumentLinearVelocity(const Eigen::Vector3d &vel);
@@ -19,6 +20,7 @@ public:
 private:
   Eigen::Vector3d vel_;
   Eigen::Vector3d omega_;
+  PredictionNoiseParam noise_param_;
   static XorShift128 rand_;
 };
 

--- a/src/amcl_3d/include/amcl_3d/prediction_model/foo_prediction_model_node.hpp
+++ b/src/amcl_3d/include/amcl_3d/prediction_model/foo_prediction_model_node.hpp
@@ -15,7 +15,8 @@ namespace amcl_3d
 class FooPredictionModelNode
 {
   public:
-    FooPredictionModelNode(rclcpp::Node & node, std::shared_ptr<Amcl> amcl);
+    FooPredictionModelNode(rclcpp::Node & node, std::shared_ptr<Amcl> amcl,
+                           const PredictionNoiseParam &noise_param = PredictionNoiseParam{});
     std::shared_ptr<PredictionModelInterface> getPredictionModel() const;
 
   private:

--- a/src/amcl_3d/include/amcl_3d/type.hpp
+++ b/src/amcl_3d/include/amcl_3d/type.hpp
@@ -59,12 +59,33 @@ struct KLDSamplingParam
     double z_bin_width;
 };
 
+struct PredictionNoiseParam
+{
+    double vel_scale_mean = 1.0;
+    double vel_scale_std = 0.2;
+    double vel_bias_mean = 0.0;
+    double vel_bias_std = 0.05;
+    double omega_scale_mean = 1.0;
+    double omega_scale_std = 0.2;
+    double omega_bias_mean = 0.0;
+    double omega_bias_std = 0.05;
+};
+
+struct LidarMeasurementParam
+{
+    int random_sample_num = 300;
+    double max_dist = 1.0;
+    double sigma = 0.5;
+};
+
 struct AmclParam
 {
     AugmentedMCLParam augmented_mcl;
     ResampleTimingParam resample_timing;
     KLDSamplingParam kld_sampling;
     InitialPoseParam init_pose;
+    PredictionNoiseParam prediction_noise;
+    LidarMeasurementParam lidar_measurement;
 };
 
 typedef std::vector<State> Particles;

--- a/src/amcl_3d/launch/amcl_3d_rosbag.launch.py
+++ b/src/amcl_3d/launch/amcl_3d_rosbag.launch.py
@@ -7,6 +7,25 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
+def _map_pcd_publisher(context):
+    pcd_file = LaunchConfiguration("map_pcd_file").perform(context).strip()
+    if not pcd_file:
+        return [LogInfo(msg="map_pcd_file is empty, skipping PCD publisher")]
+
+    map_topic = LaunchConfiguration("input_map").perform(context)
+    pcd_frame = LaunchConfiguration("map_pcd_frame").perform(context)
+
+    pkg_lib = FindPackageShare("amcl_3d").perform(context).replace("/share/amcl_3d", "/lib/amcl_3d")
+    script = pkg_lib + "/publish_pcd.py"
+
+    return [
+        ExecuteProcess(
+            cmd=["python3", script, pcd_file, map_topic, pcd_frame],
+            output="screen",
+        )
+    ]
+
+
 def _bag_play_action(context):
     bag_path = LaunchConfiguration("bag_path").perform(context).strip()
     if not bag_path:
@@ -29,6 +48,10 @@ def _bag_play_action(context):
         cmd.append("--loop")
     if LaunchConfiguration("bag_start_paused").perform(context).lower() == "true":
         cmd.append("--start-paused")
+
+    qos_overrides = LaunchConfiguration("qos_overrides_path").perform(context).strip()
+    if qos_overrides:
+        cmd.extend(["--qos-profile-overrides-path", qos_overrides])
 
     return [ExecuteProcess(cmd=cmd, output="screen")]
 
@@ -57,6 +80,9 @@ def generate_launch_description():
             DeclareLaunchArgument("bag_start_paused", default_value="false"),
             DeclareLaunchArgument("bag_start_offset", default_value="0.0"),
             DeclareLaunchArgument("clock_publish_hz", default_value="100.0"),
+            DeclareLaunchArgument("qos_overrides_path", default_value=""),
+            DeclareLaunchArgument("map_pcd_file", default_value=""),
+            DeclareLaunchArgument("map_pcd_frame", default_value="map"),
             DeclareLaunchArgument("open_rviz", default_value="true"),
             DeclareLaunchArgument("rviz_config", default_value=rviz_config),
             DeclareLaunchArgument("publish_map_to_static_tf", default_value="false"),
@@ -111,5 +137,6 @@ def generate_launch_description():
                 output="screen",
             ),
             OpaqueFunction(function=_bag_play_action),
+            OpaqueFunction(function=_map_pcd_publisher),
         ]
     )

--- a/src/amcl_3d/scripts/publish_pcd.py
+++ b/src/amcl_3d/scripts/publish_pcd.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Publish a PCD file as a PointCloud2 message with transient_local QoS."""
+
+import struct
+import sys
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import PointCloud2, PointField
+
+
+def load_pcd(path: str) -> PointCloud2:
+    """Load an ASCII PCD file and return a PointCloud2 message."""
+    with open(path) as f:
+        lines = f.readlines()
+
+    header_end = 0
+    fields_str = ""
+    sizes_str = ""
+    types_str = ""
+    counts_str = ""
+    width = 0
+    height = 1
+    data_format = ""
+
+    for i, line in enumerate(lines):
+        parts = line.strip().split()
+        if not parts:
+            continue
+        key = parts[0]
+        if key == "FIELDS":
+            fields_str = parts[1:]
+        elif key == "SIZE":
+            sizes_str = parts[1:]
+        elif key == "TYPE":
+            types_str = parts[1:]
+        elif key == "COUNT":
+            counts_str = parts[1:]
+        elif key == "WIDTH":
+            width = int(parts[1])
+        elif key == "HEIGHT":
+            height = int(parts[1])
+        elif key == "DATA":
+            data_format = parts[1]
+            header_end = i + 1
+            break
+
+    if data_format != "ascii":
+        raise ValueError(f"Only ASCII PCD supported, got: {data_format}")
+
+    # Build PointField list
+    pf_list = []
+    offset = 0
+    for name, size, dtype, count in zip(fields_str, sizes_str, types_str, counts_str):
+        size_val = int(size)
+        count_val = int(count)
+        if dtype == "F" and size_val == 4:
+            datatype = PointField.FLOAT32
+        elif dtype == "F" and size_val == 8:
+            datatype = PointField.FLOAT64
+        elif dtype == "U" and size_val == 4:
+            datatype = PointField.UINT32
+        elif dtype == "U" and size_val == 2:
+            datatype = PointField.UINT16
+        elif dtype == "U" and size_val == 1:
+            datatype = PointField.UINT8
+        elif dtype == "I" and size_val == 4:
+            datatype = PointField.INT32
+        elif dtype == "I" and size_val == 2:
+            datatype = PointField.INT16
+        elif dtype == "I" and size_val == 1:
+            datatype = PointField.INT8
+        else:
+            datatype = PointField.FLOAT32
+        pf_list.append(PointField(name=name, offset=offset, datatype=datatype, count=count_val))
+        offset += size_val * count_val
+
+    point_step = offset
+    data_lines = lines[header_end:]
+    num_points = min(len(data_lines), width * height)
+
+    # Pack binary data
+    fmt_map = {
+        PointField.FLOAT32: "f",
+        PointField.FLOAT64: "d",
+        PointField.UINT8: "B",
+        PointField.UINT16: "H",
+        PointField.UINT32: "I",
+        PointField.INT8: "b",
+        PointField.INT16: "h",
+        PointField.INT32: "i",
+    }
+    pack_fmt = "<"
+    for pf in pf_list:
+        pack_fmt += fmt_map.get(pf.datatype, "f") * pf.count
+
+    data = bytearray()
+    actual_points = 0
+    for line in data_lines:
+        vals = line.strip().split()
+        if not vals:
+            continue
+        packed_vals = []
+        for pf, val_str in zip(pf_list, vals):
+            if pf.datatype in (PointField.FLOAT32, PointField.FLOAT64):
+                packed_vals.append(float(val_str))
+            else:
+                packed_vals.append(int(float(val_str)))
+        data.extend(struct.pack(pack_fmt, *packed_vals))
+        actual_points += 1
+
+    msg = PointCloud2()
+    msg.height = 1
+    msg.width = actual_points
+    msg.fields = pf_list
+    msg.is_bigendian = False
+    msg.point_step = point_step
+    msg.row_step = point_step * actual_points
+    msg.data = bytes(data)
+    msg.is_dense = True
+    return msg
+
+
+class PcdPublisher(Node):
+    def __init__(self, pcd_path: str, topic: str, frame_id: str):
+        super().__init__("pcd_publisher")
+        qos = QoSProfile(
+            depth=1,
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        self.pub = self.create_publisher(PointCloud2, topic, qos)
+        self.get_logger().info(f"Loading PCD: {pcd_path}")
+        self.msg = load_pcd(pcd_path)
+        self.msg.header.frame_id = frame_id
+        self.get_logger().info(f"Loaded {self.msg.width} points, publishing on '{topic}' (frame: {frame_id})")
+        self.pub.publish(self.msg)
+        # Re-publish periodically for late subscribers
+        self.timer = self.create_timer(5.0, self._republish)
+
+    def _republish(self):
+        self.msg.header.stamp = self.get_clock().now().to_msg()
+        self.pub.publish(self.msg)
+
+
+def main():
+    rclpy.init()
+    pcd_path = sys.argv[1] if len(sys.argv) > 1 else "map.pcd"
+    topic = sys.argv[2] if len(sys.argv) > 2 else "/mapcloud"
+    frame_id = sys.argv[3] if len(sys.argv) > 3 else "map"
+    node = PcdPublisher(pcd_path, topic, frame_id)
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/amcl_3d/src/mcl.cpp
+++ b/src/amcl_3d/src/mcl.cpp
@@ -44,9 +44,9 @@ bool Amcl::measureLidar(const Time &time, const pcl::PointCloud<pcl::PointXYZ>::
     if (particles_ptr == nullptr || particles_ptr->empty())
         return false;
     MeasurementState measurement_state;
-    const size_t random_sample_num = 100;
-    const double max_dist = 0.2;
-    const double sigma = 1.0;
+    const size_t random_sample_num = param_.lidar_measurement.random_sample_num;
+    const double max_dist = param_.lidar_measurement.max_dist;
+    const double sigma = param_.lidar_measurement.sigma;
     std::shared_ptr<MeasurementModelInterface> model =
         std::make_shared<LidarMeasurementModel>(kd_map_ptr_, measuement, random_sample_num, max_dist, sigma);
     pf_ptr_->measure(model, measurement_state);
@@ -106,10 +106,7 @@ bool Amcl::checkResample(const MeasurementState &measurement_state)
             std::make_shared<NormalDistribution>(/*avg*/ 0.0, /*var*/ param_.augmented_mcl.noise_yaw_var);
         ParticleFilter::NoiseGenerators
             noise_gens(x_noise_ptr, y_noise_ptr, z_noise_ptr, roll_noise_ptr, pitch_noise_ptr, yaw_noise_ptr);
-        pf_ptr_->resample(pf_ptr_->getParticleNum()); // simple resample
-        // pf_ptr_->resample(pf_ptr_->getParticleNum(), 0.2, noise_gens); // random resample
-        // pf_ptr_->resample(pf_ptr_->getParticleNum(), random_sampling_ratio, noise_gens); // augmented resample
-        // pf_ptr_->resample(param_.kld_sampling, random_sampling_ratio, noise_gens); // random resample and kld sample
+        pf_ptr_->resample(param_.kld_sampling, random_sampling_ratio, noise_gens); // KLD + augmented resample
     }
     return true;
 }

--- a/src/amcl_3d/src/node.cpp
+++ b/src/amcl_3d/src/node.cpp
@@ -133,6 +133,28 @@ Amcl3dNode::Amcl3dNode() : rclcpp::Node("amcl_3d")
       this->declare_parameter<double>("amcl_param.kld_sampling.y_bin_width", 0.2);
   amcl_param.kld_sampling.z_bin_width =
       this->declare_parameter<double>("amcl_param.kld_sampling.z_bin_width", 0.2);
+  amcl_param.prediction_noise.vel_scale_mean =
+      this->declare_parameter<double>("amcl_param.prediction_noise.vel_scale_mean", 1.0);
+  amcl_param.prediction_noise.vel_scale_std =
+      this->declare_parameter<double>("amcl_param.prediction_noise.vel_scale_std", 0.2);
+  amcl_param.prediction_noise.vel_bias_mean =
+      this->declare_parameter<double>("amcl_param.prediction_noise.vel_bias_mean", 0.0);
+  amcl_param.prediction_noise.vel_bias_std =
+      this->declare_parameter<double>("amcl_param.prediction_noise.vel_bias_std", 0.05);
+  amcl_param.prediction_noise.omega_scale_mean =
+      this->declare_parameter<double>("amcl_param.prediction_noise.omega_scale_mean", 1.0);
+  amcl_param.prediction_noise.omega_scale_std =
+      this->declare_parameter<double>("amcl_param.prediction_noise.omega_scale_std", 0.2);
+  amcl_param.prediction_noise.omega_bias_mean =
+      this->declare_parameter<double>("amcl_param.prediction_noise.omega_bias_mean", 0.0);
+  amcl_param.prediction_noise.omega_bias_std =
+      this->declare_parameter<double>("amcl_param.prediction_noise.omega_bias_std", 0.05);
+  amcl_param.lidar_measurement.random_sample_num = static_cast<int>(
+      this->declare_parameter<int64_t>("amcl_param.lidar_measurement.random_sample_num", 300));
+  amcl_param.lidar_measurement.max_dist =
+      this->declare_parameter<double>("amcl_param.lidar_measurement.max_dist", 1.0);
+  amcl_param.lidar_measurement.sigma =
+      this->declare_parameter<double>("amcl_param.lidar_measurement.sigma", 0.5);
 
   map_frame_id_ = this->declare_parameter<std::string>("map_frame_id", "map");
   base_link_frame_id_ = this->declare_parameter<std::string>("base_link_frame_id", "base_link");
@@ -144,7 +166,7 @@ Amcl3dNode::Amcl3dNode() : rclcpp::Node("amcl_3d")
   }
 
   amcl_ = std::make_shared<Amcl>(amcl_param);
-  prediction_model_node_ = std::make_shared<FooPredictionModelNode>(*this, amcl_);
+  prediction_model_node_ = std::make_shared<FooPredictionModelNode>(*this, amcl_, amcl_param.prediction_noise);
 
   const auto latched_qos = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
   pf_pub_ = this->create_publisher<geometry_msgs::msg::PoseArray>("particles", latched_qos);

--- a/src/amcl_3d/src/prediction_model/foo_prediction_model.cpp
+++ b/src/amcl_3d/src/prediction_model/foo_prediction_model.cpp
@@ -8,6 +8,12 @@ FooPredictionModel::FooPredictionModel()
     vel_ << 0.0, 0.0, 0.0;
     omega_ << 0.0, 0.0, 0.0;
 }
+FooPredictionModel::FooPredictionModel(const PredictionNoiseParam &noise_param)
+    : noise_param_(noise_param)
+{
+    vel_ << 0.0, 0.0, 0.0;
+    omega_ << 0.0, 0.0, 0.0;
+}
 FooPredictionModel::FooPredictionModel(const Eigen::Vector3d &vel,
                                        const Eigen::Vector3d &omega)
     : vel_(vel), omega_(omega)
@@ -18,10 +24,10 @@ bool FooPredictionModel::predict(State &state, const double dt_sec)
 {
     Position local_position;
     Quat local_quat;
-    std::normal_distribution<double> vel_scale_noise(1.0, 1.0),
-        vel_bias_noise(0.0, 0.2),
-        omega_scale_noise(1.0, 0.5),
-        omega_bias_noise(0.0, 0.1);
+    std::normal_distribution<double> vel_scale_noise(noise_param_.vel_scale_mean, noise_param_.vel_scale_std),
+        vel_bias_noise(noise_param_.vel_bias_mean, noise_param_.vel_bias_std),
+        omega_scale_noise(noise_param_.omega_scale_mean, noise_param_.omega_scale_std),
+        omega_bias_noise(noise_param_.omega_bias_mean, noise_param_.omega_bias_std);
     double vel = vel_.x() * vel_scale_noise(rand_) + vel_bias_noise(rand_);
     double omega = omega_.z() * omega_scale_noise(rand_) + omega_bias_noise(rand_);
     const double r = vel / omega;

--- a/src/amcl_3d/src/prediction_model/foo_prediction_model_node.cpp
+++ b/src/amcl_3d/src/prediction_model/foo_prediction_model_node.cpp
@@ -4,10 +4,11 @@
 
 namespace amcl_3d
 {
-FooPredictionModelNode::FooPredictionModelNode(rclcpp::Node & node, std::shared_ptr<Amcl> amcl)
+FooPredictionModelNode::FooPredictionModelNode(rclcpp::Node & node, std::shared_ptr<Amcl> amcl,
+                                               const PredictionNoiseParam &noise_param)
     : node_(node), amcl_(std::move(amcl))
 {
-    prediction_model_ = std::make_shared<FooPredictionModel>();
+    prediction_model_ = std::make_shared<FooPredictionModel>(noise_param);
     odom_sub_ = node_.create_subscription<nav_msgs::msg::Odometry>(
         "odom",
         rclcpp::SensorDataQoS(),


### PR DESCRIPTION
## Summary

- Enable KLD+augmented resampling (previously only simple resample was active, making noise_*_var and KLD params unused)
- Parameterize prediction model noise via YAML (was hard-coded with vel_scale_std=1.0, far too noisy)
- Parameterize measurement model (random_sample_num, max_dist, sigma) via YAML
- Tune defaults for better convergence: reduced prediction noise, increased sample count, enabled noise-injected resampling

## Key parameter changes

| Parameter | Before | After | Reason |
|---|---|---|---|
| Resample method | simple (no noise) | KLD+augmented | Maintains particle diversity |
| vel_scale_std | 1.0 (hard-coded) | 0.2 (configurable) | Prevents velocity from scaling 0x-2x |
| random_sample_num | 100 (hard-coded) | 300 (configurable) | More measurement points for accuracy |
| max_dist | 0.2 (hard-coded) | 1.0 (configurable) | Relaxed outlier rejection |
| initial_particle_num | 100 | 500 | Better initial coverage |

## Test plan

- [x] Unit tests pass (4/4 gtest)
- [x] Verified with Kinematic-ICP Husky bag (map→odom TF, particles converge)
- [x] Verified with short_test_ros2 bag (map→odom TF published)
- [x] KLD sampling active (particle count adapts from min=100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)